### PR TITLE
Add patch for ms sql drivers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ Insert into a table
 
     df = pd.DataFrame(sample_data)
     sql = MSSQL()
-    sql.insert_into("table_name", df) 
+    sql.insert_into("table_name", df)
 
 
 Execute a stored procedure

--- a/docs/source/cookbook/environment.rst
+++ b/docs/source/cookbook/environment.rst
@@ -65,6 +65,7 @@ you can combine the params in your `.env` file for easy management.
     MS_SCHEMA=
     MS_USER=
     MS_PWD=
+    MS_DRIVER=(optional if not using a system with a single driver install)
 
 **MySQL**
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, "README.rst"), encoding="utf-8") as f:
 
 setup(
     name="sqlsorcery",
-    version="0.1.4",
+    version="0.1.5",
     description="Dead simple wrapper for pandas and sqlalchemy",
     long_description=long_description,
     long_description_content_type="text/x-rst",

--- a/sqlsorcery/__init__.py
+++ b/sqlsorcery/__init__.py
@@ -216,7 +216,7 @@ class MSSQL(Connection):
         for connecting to MS SQL."""
 
     def __init__(
-        self, schema=None, port=None, server=None, db=None, user=None, pwd=None
+        self, schema=None, port=None, server=None, db=None, user=None, pwd=None, driver=None
     ):
         """Initializes an MS SQL database connection
 
@@ -238,6 +238,8 @@ class MSSQL(Connection):
             **Security Warning**: always pass this in with environment
             variables when used in production.
         :type pwd: string
+        :param driver: Name of MS SQL driver installed in system
+        :type driver: string
         """
         self.server = server or getenv("MS_SERVER") or getenv("DB_SERVER")
         self.port = port or getenv("MS_PORT") or getenv("DB_PORT") or "1433"
@@ -245,9 +247,12 @@ class MSSQL(Connection):
         self.user = user or getenv("MS_USER") or getenv("DB_USER")
         self.pwd = pwd or getenv("MS_PWD") or getenv("DB_PWD")
         self.schema = schema or getenv("MS_SCHEMA") or getenv("DB_SCHEMA") or "dbo"
-        self.driver = pyodbc.drivers()[-1].replace(" ", "+")
+        self.driver = driver or getenv("MS_DRIVER") or self._get_driver()
         cstr = f"mssql+pyodbc://{self.user}:{self.pwd}@{self.server}:{self.port}/{self.db}?driver={self.driver}"
         self.engine = create_engine(cstr, fast_executemany=True)
+
+    def _get_driver(self):
+        return pyodbc.drivers()[-1].replace(" ", "+")
 
 
 class MySQL(Connection):


### PR DESCRIPTION
Fixes #31 
When a system has more than one installation of the pydobc drivers, the previous method of setting the drivers automatically fails. This patch adds an option to pass in the driver string as a param or as an env var instead of automatically picking the drivers from the system using `pyodbc.drivers()`.